### PR TITLE
HOP-2303 - Remove instance of duplicate download path

### DIFF
--- a/hop-user-manual/modules/ROOT/pages/getting-started.adoc
+++ b/hop-user-manual/modules/ROOT/pages/getting-started.adoc
@@ -5,7 +5,7 @@
 
 
 == Getting Started with Hop
-* https://hop.apache.org/download/download/[Download] a recent Hop build.
+* https://hop.apache.org/download/[Download] a recent Hop build.
 * unzip hop to a local directory
 * change to the hop directory
 


### PR DESCRIPTION
- Changed instance of "/download/download/" to "/download/" in the getting started doc.

This related to a change to incubator-hop-website.