### PR TITLE
Added Run Apache Hop section.

### DIFF
--- a/hop-dev-manual/modules/ROOT/pages/setup-dev-environment.adoc
+++ b/hop-dev-manual/modules/ROOT/pages/setup-dev-environment.adoc
@@ -109,6 +109,16 @@ limitations under the License.
 
 Set this as the default copyright profile for all files.
 
+== Run Apache Hop
+
+After a successful build, the Hop UI can be started.
+
+    $ cd assemblies/client/target
+    $ unzip hop-client-*.zip
+    $ cd hop 
+
+On Windows, run `hop-gui.bat`, on Mac and Linux, run `hop-gui.sh` 
+
 == Debugging
 
 To debug the Hop GUI or a long running pipeline or workflow you can change the launch scripts and uncomment the line with the 5005 port in it:


### PR DESCRIPTION
Running sections is missing on website docs, took it from [Apache Hop GitHub README.md](https://github.com/apache/incubator-hop/blob/master/README.md).